### PR TITLE
Merge commits from AzureAD/passport-azure-ad v3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 <a name="3.0.1"></a>
+# 3.0.3
+
+## Bug fixes
+
+* [#248](https://github.com/AzureAD/passport-azure-ad/issues/248) End_to_end_test showing up in test folder
+
 # 3.0.2
 
 ## Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@
 
 * specify tenant per request 
 
-  Now you can specify the tenant per request, using the `tenantIdOrName` option in `passport.authenticate`. More details on the usage can be found in README.md. This brings us two additional benefits:
+  Now you can specify the tenant per request, using the `tenantIdOrName` option in `passport.authenticate`. More details on the usage can be found in README.md. `tenantIdOrName` enables two features:
 
   * B2C common endpoint support
 
-    Now you can use B2C common endpoint, if you specify the tenant for each login request (in other words, a request that doesn't contain code or id_token) using the `tenantIdOrName` option.
+    Now you can use the B2C common endpoint by specifying the tenant for each login request using the `tenantIdOrName` option. A login request is any request that doesn't contain code or id_token in the responseType.
 
   * extensive issuer validation on common endpoint
     
-    If you want to validate issuer on common endpoint, previously you have to provide `issuer`in configuration. Now you can either provide `issuer`, or specify the tenant for each login request.
+    Previously, you had to provide an `issuer` value in configuration to validat the issuer on the common endpoint. Alternatively, you can now specify the tenant for each login request.
 
 # 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
   * B2C common endpoint support
 
-    Now you can use the B2C common endpoint by specifying the tenant for each login request using the `tenantIdOrName` option. A login request is any request that doesn't contain code or id_token in the responseType.
+    Now you can use the B2C common endpoint by specifying the tenant for each login request using the `tenantIdOrName` option. A login request is any request that doesn't contain code or id_token.
 
   * extensive issuer validation on common endpoint
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 <a name="3.0.1"></a>
+# 3.0.2
+
+## Changes
+
+* removed dependency on oniyi-object-transform
+
+* allow 5 minutes clock skew for token validation
+
 # 3.0.1
 
 ## OIDCStrategy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@
     
     Previously, you had to provide an `issuer` value in configuration to validat the issuer on the common endpoint. Alternatively, you can now specify the tenant for each login request.
 
+## Bug fixes
+
+* [#239](https://github.com/AzureAD/passport-azure-ad/issues/239) Problems with signin in the updated sample
+
+* [#233](https://github.com/AzureAD/passport-azure-ad/issues/233) Provide documentation with more details
+
+* [#229](https://github.com/AzureAD/passport-azure-ad/issues/229) use tenant id dynamically for each request
+
+* [#123](https://github.com/AzureAD/passport-azure-ad/issues/123) Question: what is the difference between OIDCStrategy and BearerStrategy. Which one should I use?
+
 # 3.0.0
 
 ## OIDCStrategy

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ app.get('/logout', function(req, res){
 
 * `failureRedirect`: the url redirected to when the authentication fails
 
-* `session`: if you don't want a persistent login session, you can use `session: false`
+* `session`: if you don't want a persistent login session, you can use `session: false`. The default value is true.
 
 * `customState`: if you want to use a custom state value instead of a random generated one
 
@@ -377,7 +377,7 @@ In the following example, we are using passport to protect '/api/tasks'. User se
 
 #### 5.2.3 Options available for `passport.authenticate`
 
-* `session`: if you don't want a persistent login session, you can use `session: false`
+* `session`: if you don't want a persistent login session, you can use `session: false`. The default value is true.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and with [Microsoft Active Directory Federation Services](http://en.wikipedia.or
 _passport-azure-ad_ has a known security vulnerability affecting versions <1.4.6 and 2.0.0. Please update to >=1.4.6 or >=2.0.1 immediately. For more details, see the [security notice](https://github.com/AzureAD/passport-azure-ad/blob/master/SECURITY-NOTICE.MD).
 
 ## 2. Versions
-Current version - 3.0.2  
+Current version - 3.0.3  
 Minimum  recommended version - 1.4.6  
 You can find the changes for each version in the [change log](https://github.com/AzureAD/passport-azure-ad/blob/master/CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and with [Microsoft Active Directory Federation Services](http://en.wikipedia.or
 _passport-azure-ad_ has a known security vulnerability affecting versions <1.4.6 and 2.0.0. Please update to >=1.4.6 or >=2.0.1 immediately. For more details, see the [security notice](https://github.com/AzureAD/passport-azure-ad/blob/master/SECURITY-NOTICE.MD).
 
 ## 2. Versions
-Current version - 3.0.1  
+Current version - 3.0.2  
 Minimum  recommended version - 1.4.6  
 You can find the changes for each version in the [change log](https://github.com/AzureAD/passport-azure-ad/blob/master/CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ You can find the changes for each version in the [change log](https://github.com
 
 ## 5. Usage
 
-This library contains two strategies, OIDCStrategy and BearerStrategy.
+This library contains two strategies: OIDCStrategy and BearerStrategy.
 
-OIDCStrategy is for web application login purpose using OpenID connect protocol. It works in the following way:
- If a user is not logged in, passport sends an authentication request to AAD (Azure Active Directory), then AAD returns a login page to let the user enter their credentials. Once the credentials is authenticated by AAD, the web application will eventually get an id_token back (directly from AAD authentication endpoint, or by redeeming a code at AAD token endpoint, depending on the flow you choose). Passport then validates the id_token and propagates the claims in id_token back to the verify callback, and let the passport framework finish the remaining authentication procedures. If the whole process is successful, passport adds the user information into `req.user` and passes it to the next middleware; otherwise, passport sends back an authorized response or redirects the user to the page you specify (such as homepage or login page).
+OIDCStrategy uses OpenID Connect protocol for web application login purposes. It works in the following manner:
+If a user is not logged in, passport sends an authentication request to AAD (Azure Active Directory), and AAD prompts the user for his or her sign-in credentials. On successful authentication, depending on the flow you choose, web application will eventually get an id_token back either directly from the AAD authorization endpoint or by redeeming a code at the AAD token endpoint. Passport then validates the id_token and propagates the claims in id_token back to the verify callback, and let the framework finish the remaining authentication procedure. If the whole process is successful, passport adds the user information to `req.user` and passes it to the next middleware. In case of error, passport either sends back an unauthorized response or redirects the user to the page you specified (such as homepage or login page).
 
-BearerStrategy is for protecting web resource/api purpose using Bearer Token protocol. It works in the following way:
- User sends a request to the protected web api, and the request is supposed to contain an access_token in either authorization header or body. Passport extracts and validates the access_token, and propagates the claims in access_token to the verify callback and let the passport framework finish the remaining authentication procedure. If the whole process is successful, passport adds the user information into `req.user` and passes it to the next middleware, which is usually the business logic of the web resource/api; otherwise, passport sends back an authorized response.
+BearerStrategy uses Bearer Token protocol to protect web resource/api. It works in the following manner:
+User sends a request to the protected web api which contains an access_token in either the authorization header or body. Passport extracts and validates the access_token, and propagates the claims in access_token to the verify callback and let the framework finish the remaining authentication procedure. On successful authentication, passport adds the user information to `req.user` and passes it to the next middleware, which is usually the business logic of the web resource/api. In case of error, passport sends back an unauthorized response.
+
 
 We support AAD v1, v2 and B2C tenants for both strategies. Please check out section 7 for the samples. You can manage v1 tenants and register applications at https://manage.windowsazure.com. For v2 tenants and applications, you should go to https://apps.dev.microsoft.com. For B2C tenants, go to https://manage.windowsazure.com and click 'Manage B2C settings' to register applications and policies. 
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *  All Rights Reserved
+ *  MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the 'Software'), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+'use strict';
+
+// constants that are not strategy specific
+
+var CONSTANTS = {};
+CONSTANTS.POLICY_REGEX = /^b2c_1_[0-9a-z._-]+$/i;    // policy is case insensitive
+CONSTANTS.TENANTNAME_REGEX = /^[0-9a-zA-Z]+.onmicrosoft.com$/;
+CONSTANTS.TENANTID_REGEX = /^[0-9a-zA-Z-]+$/;
+
+module.exports = CONSTANTS;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -26,8 +26,11 @@
 // constants that are not strategy specific
 
 var CONSTANTS = {};
+
 CONSTANTS.POLICY_REGEX = /^b2c_1_[0-9a-z._-]+$/i;    // policy is case insensitive
 CONSTANTS.TENANTNAME_REGEX = /^[0-9a-zA-Z]+.onmicrosoft.com$/;
 CONSTANTS.TENANTID_REGEX = /^[0-9a-zA-Z-]+$/;
+
+CONSTANTS.CLOCK_SKEW = 300; // 5 minutes
 
 module.exports = CONSTANTS;

--- a/lib/jsonWebToken.js
+++ b/lib/jsonWebToken.js
@@ -24,6 +24,7 @@
 'use restrict';
 
 const jws = require('jws');
+const constants = require('./constants');
 
 /* Verify the token and return the payload
  *
@@ -178,7 +179,7 @@ exports.verify = function(jwtString, PEMKey, options, callback) {
   if (typeof payload.exp !== 'number')
     return done(new Error('invalid exp value in payload'));
   if (!options.ignoreExpiration) {
-    if (Math.floor(Date.now() / 1000) >= payload.exp) {
+    if (Math.floor(Date.now() / 1000) >= payload.exp + constants.CLOCK_SKEW) {
       return done(new Error('jwt is expired'));
     }
   }
@@ -186,9 +187,9 @@ exports.verify = function(jwtString, PEMKey, options, callback) {
   // (5) nbf
   //   - check if it exists
   if (payload.nbf) {
-    if (typeof payload.nbf !== 'number')
+    if (typeof payload.nbf !== 'number' || payload.nbf >= payload.exp)
       return done(new Error('invalid nbf value in payload'));
-    if (payload.nbf > Math.ceil(Date.now() / 1000) + 1)  // add 1 more second to allow the clock screw
+    if (payload.nbf >= Math.floor(Date.now() / 1000) + constants.CLOCK_SKEW)
       return done(new Error('jwt is not active'));
   }
 

--- a/lib/jsonWebToken.js
+++ b/lib/jsonWebToken.js
@@ -187,8 +187,10 @@ exports.verify = function(jwtString, PEMKey, options, callback) {
   // (5) nbf
   //   - check if it exists
   if (payload.nbf) {
-    if (typeof payload.nbf !== 'number' || payload.nbf >= payload.exp)
-      return done(new Error('invalid nbf value in payload'));
+    if (typeof payload.nbf !== 'number')
+      return done(new Error('nbf value in payload is not a number'));
+    if (payload.nbf >= payload.exp)
+      return done(new Error('nbf value in payload is not before the exp value'));
     if (payload.nbf >= Math.floor(Date.now() / 1000) + constants.CLOCK_SKEW)
       return done(new Error('jwt is not active'));
   }

--- a/lib/jsonWebToken.js
+++ b/lib/jsonWebToken.js
@@ -188,7 +188,7 @@ exports.verify = function(jwtString, PEMKey, options, callback) {
   if (payload.nbf) {
     if (typeof payload.nbf !== 'number')
       return done(new Error('invalid nbf value in payload'));
-    if (payload.nbf > Math.ceil(Date.now() / 1000))
+    if (payload.nbf > Math.ceil(Date.now() / 1000) + 1)  // add 1 more second to allow the clock screw
       return done(new Error('jwt is not active'));
   }
 

--- a/lib/jsonWebToken.js
+++ b/lib/jsonWebToken.js
@@ -188,7 +188,7 @@ exports.verify = function(jwtString, PEMKey, options, callback) {
   if (payload.nbf) {
     if (typeof payload.nbf !== 'number')
       return done(new Error('invalid nbf value in payload'));
-    if (payload.nbf > Math.floor(Date.now() / 1000))
+    if (payload.nbf > Math.ceil(Date.now() / 1000))
       return done(new Error('jwt is not active'));
   }
 

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -72,7 +72,7 @@ Metadata.prototype.updateOidcMetadata = function updateOidcMetadata(doc, next) {
 
   var oidc = {};
   oidc.algorithms = doc.id_token_signing_alg_values_supported;
-  oidc.auth_endpoint = doc.authorization_endpoint;
+  oidc.authorization_endpoint = doc.authorization_endpoint;
   oidc.end_session_endpoint = doc.end_session_endpoint;
   oidc.issuer = doc.issuer;
   oidc.token_endpoint = doc.token_endpoint;
@@ -84,7 +84,7 @@ Metadata.prototype.updateOidcMetadata = function updateOidcMetadata(doc, next) {
   log.info('Algorithm retrieved was: ', self.oidc.algorithms);
   log.info('Issuer we are using is: ', self.oidc.issuer);
   log.info('Key Endpoint we will use is: ', jwksUri);
-  log.info('Authentication endpoint we will use is: ', self.oidc.auth_endpoint);
+  log.info('Authentication endpoint we will use is: ', self.oidc.authorization_endpoint);
   log.info('Token endpoint we will use is: ', self.oidc.token_endpoint);
   log.info('User info endpoint we will use is: ', self.oidc.userinfo_endpoint);
   log.info('The logout endpoint we will use is: ', self.oidc.end_session_endpoint);

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -25,7 +25,6 @@
 
 const request = require('request');
 const async = require('async');
-const objectTransform = require('oniyi-object-transform');
 const aadutils = require('./aadutils');
 
 const Log = require('./logging').getLogger;
@@ -71,19 +70,15 @@ Metadata.prototype.updateOidcMetadata = function updateOidcMetadata(doc, next) {
 
   const self = this;
 
-  self.oidc = objectTransform({
-    source: doc,
-    map: {
-      id_token_signing_alg_values_supported: 'algorithms',
-      authorization_endpoint: 'auth_endpoint',
-    },
-    pick: [
-      'end_session_endpoint',
-      'issuer',
-      'token_endpoint',
-      'userinfo_endpoint',
-    ],
-  });
+  var oidc = {};
+  oidc.algorithms = doc.id_token_signing_alg_values_supported;
+  oidc.auth_endpoint = doc.authorization_endpoint;
+  oidc.end_session_endpoint = doc.end_session_endpoint;
+  oidc.issuer = doc.issuer;
+  oidc.token_endpoint = doc.token_endpoint;
+  oidc.userinfo_endpoint = doc.userinfo_endpoint;
+  self.oidc = oidc;
+
   const jwksUri = doc.jwks_uri;
 
   log.info('Algorithm retrieved was: ', self.oidc.algorithms);

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -357,10 +357,6 @@ function Strategy(options, verify) {
   if (options.isB2C !== true)
     options.isB2C = false;
 
-  // common endpoint will not work for B2C unless they provide the tenant name or tenant guid in 'passport.authenticate'
-  if (options.isCommonEndpoint && options.isB2C)
-    log.info(`In order to use common endpoint for B2C, please provide your tenant name or tenant guid when you call 'passport.authenticate'.`);
-
   // add telemetry
   options.identityMetadata = options.identityMetadata.concat(`?${aadutils.getLibraryProductParameterName()}=${aadutils.getLibraryProduct()}`)
   .concat(`&${aadutils.getLibraryVersionParameterName()}=${aadutils.getLibraryVersion()}`);

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -39,6 +39,7 @@ const util = require('util');
 
 // packages from this library
 const aadutils = require('./aadutils');
+const CONSTANTS = require('./constants');
 const jwt = require('./jsonWebToken');
 
 // For the following packages we get a constructor and we will use 'new' to create an instance
@@ -66,9 +67,6 @@ const ttl = 1800; // 30 minutes cache
 //    recent 10 tabs within the life time.
 const NONCE_MAX_AMOUNT = 10;
 const NONCE_LIFE_TIME = 3600; // second
-
-// B2C policy is like 'b2c_1_policyname'. policy is not case sensitive. 
-const B2C_PREFIX = 'b2c_1_';
 
 function makeProfileObject(src, raw) {
   return {
@@ -500,6 +498,10 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
   var customState = options && options.customState;
   var tenantIdOrName = options && options.tenantIdOrName;
 
+  // validate tenantIdOrName if it is provided
+  if (tenantIdOrName && !CONSTANTS.TENANTNAME_REGEX.test(tenantIdOrName) && !CONSTANTS.TENANTID_REGEX.test(tenantIdOrName))
+    return self.failWithLog(`In passport.authenticate: invalid tenantIdOrName ${tenantIdOrName}`);
+
   // 'params': items we get from the request or metadata, such as id_token, code, policy, metadata, cacheKey, etc
   var params = { 'tenantIdOrName': tenantIdOrName }; 
   // 'oauthConfig': items needed for oauth flow (like redirection, code redemption), such as token_endpoint, userinfo_endpoint, etc
@@ -843,7 +845,7 @@ Strategy.prototype._validateResponse = function validateResponse(params, options
 
     // For B2C, check the policy
     if (self._options.isB2C) {
-      if (!jwtClaims.acr || jwtClaims.acr.length <= B2C_PREFIX.length || jwtClaims.acr.substring(0,6).toLowerCase() !== B2C_PREFIX)
+      if (!jwtClaims.acr || !CONSTANTS.POLICY_REGEX.test(jwtClaims.acr))
         return next(new Error('In _validateResponse: invalid B2C policy in id_token'));
 
       if (params.policy !== jwtClaims.acr)
@@ -1155,7 +1157,7 @@ Strategy.prototype._flowInitializationHandler = function flowInitializationHandl
       return next(new Error('In _flowInitializationHandler: missing policy in the request for B2C'));
     // policy is not case sensitive. AAD turns policy to lower case.
     policy = req.query.p.toLowerCase();
-    if (!policy.startsWith(B2C_PREFIX))
+    if (!policy || !CONSTANTS.POLICY_REGEX.test(policy))
       return next(new Error(`In _flowInitializationHandler: the given policy ${policy} given in the request is invalid`));
   }
   // add state/nonce/policy/timeStamp tuple to session

--- a/lib/oidcstrategy.js
+++ b/lib/oidcstrategy.js
@@ -713,13 +713,13 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
       params.metadata = metadata;
       
       // copy the fields needed into 'oauthConfig'
-      aadutils.copyObjectFields(metadata.oidc, oauthConfig, ['auth_endpoint', 'token_endpoint', 'userinfo_endpoint']);
+      aadutils.copyObjectFields(metadata.oidc, oauthConfig, ['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint']);
       aadutils.copyObjectFields(self._options, oauthConfig, ['clientID', 'clientSecret', 'responseType', 'responseMode', 'scope', 'redirectUrl']);
       oauthConfig.tenantIdOrName = params.tenantIdOrName;
 
       // validate oauthConfig
       const validatorConfig = {
-        auth_endpoint: Validator.isHttpsURL,
+        authorization_endpoint: Validator.isHttpsURL,
         token_endpoint: Validator.isHttpsURL,
         userinfo_endpoint: Validator.isHttpsURLIfExists,
       };
@@ -743,8 +743,8 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
           return u.query && u.query.p && (policy.toLowerCase() === u.query.p.toLowerCase());
         };
         // B2C has no userinfo_endpoint, so no need to check it
-        if (!policyChecker(oauthConfig.auth_endpoint, params.policy))
-          return next(new Error(`policy in ${oauthConfig.auth_endpoint} should be ${params.policy}`));
+        if (!policyChecker(oauthConfig.authorization_endpoint, params.policy))
+          return next(new Error(`policy in ${oauthConfig.authorization_endpoint} should be ${params.policy}`));
         if (!policyChecker(oauthConfig.token_endpoint, params.policy))
           return next(new Error(`policy in ${oauthConfig.token_endpoint} should be ${params.policy}`));
       }
@@ -1008,7 +1008,7 @@ Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(params, o
     oauthConfig.clientID, // consumerKey
     oauthConfig.clientSecret, // consumer secret
     '', // baseURL (empty string because we use absolute urls for authorize and token paths)
-    oauthConfig.auth_endpoint, // authorizePath
+    oauthConfig.authorization_endpoint, // authorizePath
     oauthConfig.token_endpoint, // accessTokenPath
     {libraryProductParameterName : libraryProduct,
      libraryVersionParameterName : libraryVersion} // customHeaders
@@ -1174,9 +1174,9 @@ Strategy.prototype._flowInitializationHandler = function flowInitializationHandl
 
   // Implement support for standard OpenID Connect params (display, prompt, etc.)
   if (self._options.isB2C)
-    location = `${oauthConfig.auth_endpoint}&${querystring.stringify(params)}`;
+    location = `${oauthConfig.authorization_endpoint}&${querystring.stringify(params)}`;
   else
-    location = `${oauthConfig.auth_endpoint}?${querystring.stringify(params)}`;
+    location = `${oauthConfig.authorization_endpoint}?${querystring.stringify(params)}`;
 
   return self.redirect(location);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-azure-ad",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "MIT",
   "keywords": [
     "saml",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-azure-ad",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "license": "MIT",
   "keywords": [
     "saml",
@@ -48,7 +48,6 @@
     "jws": "^3.1.3",
     "lodash": "^4.11.2",
     "oauth": "^0.9.14",
-    "oniyi-object-transform": "^1.0.0",
     "passport": "^0.3.2",
     "pkginfo": "^0.4.0",
     "request": "^2.72.0",

--- a/test/Chai-passport_test/b2c_oidc_hybrid_and_code_flow_test.js
+++ b/test/Chai-passport_test/b2c_oidc_hybrid_and_code_flow_test.js
@@ -108,7 +108,7 @@ var setReqFromAuthRespRedirect = function(id_token_in_auth_resp, code_in_auth_re
       optionsToValidate.algorithms = ['RS256'];
       optionsToValidate.nonce = nonce_to_use;
 
-      oauthConfig.auth_endpoint = "https://login.microsoftonline.com/sijun1b2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1_signin";
+      oauthConfig.authorization_endpoint = "https://login.microsoftonline.com/sijun1b2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1_signin";
       oauthConfig.redirectUrl = "https://localhost:3000/auth/openid/return";
       oauthConfig.clientID = "f0b6e4eb-2d8c-40b6-b9c6-e26d1074846d";
       oauthConfig.token_endpoint = "https://login.microsoftonline.com/sijun1b2c.onmicrosoft.com/oauth2/v2.0/token?p=b2c_1_signin";

--- a/test/Chai-passport_test/b2c_oidc_implicit_flow_test.js
+++ b/test/Chai-passport_test/b2c_oidc_implicit_flow_test.js
@@ -86,7 +86,7 @@ var testPrepare = function(id_token_to_use, nonce_to_use, policy_to_use, action)
     testStrategy.setOptions = function(params, oauthConfig, optionsToValidate, done) {
       params.metadata.generateOidcPEM = () => { return PEMkey; };
 
-      oauthConfig.auth_endpoint = 'https://login.microsoftonline.com/sijun1b2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1_signin';
+      oauthConfig.authorization_endpoint = 'https://login.microsoftonline.com/sijun1b2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1_signin';
       oauthConfig.token_endpoint = 'https://login.microsoftonline.com/sijun1b2c.onmicrosoft.com/oauth2/v2.0/token?p=b2c_1_signin';
 
       optionsToValidate.validateIssuer = true;

--- a/test/Chai-passport_test/b2c_oidc_incoming_request_test.js
+++ b/test/Chai-passport_test/b2c_oidc_incoming_request_test.js
@@ -49,7 +49,7 @@ var testStrategy = new OIDCStrategy(options, function(profile, done) {});
 
 // Mock `setOptions`
 testStrategy.setOptions = function(params, oauthConfig, optionsToValidate, done) {
-  oauthConfig.auth_endpoint = 'https://login.microsoftonline.com/sijun1b2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1_signin';
+  oauthConfig.authorization_endpoint = 'https://login.microsoftonline.com/sijun1b2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1_signin';
   oauthConfig.token_endpoint = 'https://login.microsoftonline.com/sijun1b2c.onmicrosoft.com/oauth2/v2.0/token?p=b2c_1_signin';
 
   done();

--- a/test/Chai-passport_test/constants_test.js
+++ b/test/Chai-passport_test/constants_test.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Microsoft Corporation
+ *  All Rights Reserved
+ *  MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the 'Software'), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+'use strict';
+
+var chai = require('chai');
+var expect = chai.expect;
+var CONSTANTS = require('../../lib/constants');
+
+CONSTANTS.TENANTNAME_REGEX = /^[0-9a-zA-Z]+.onmicrosoft.com$/;
+CONSTANTS.TENANTID_REGEX = /^[0-9a-zA-Z-]+$/;
+
+describe('policy checking', function() {
+  it('should pass with good policy name', function(done) {
+    expect(CONSTANTS.POLICY_REGEX.test('b2c_1_signin')).to.equal(true);
+    expect(CONSTANTS.POLICY_REGEX.test('B2C_1_SIGNIN')).to.equal(true);
+    expect(CONSTANTS.POLICY_REGEX.test('B2C_1_My.SIGNIN')).to.equal(true);
+    expect(CONSTANTS.POLICY_REGEX.test('B2C_1_My_SIGNIN')).to.equal(true);
+    expect(CONSTANTS.POLICY_REGEX.test('B2C_1_My-SIGNIN')).to.equal(true);
+    done();
+  });
+
+  it('should fail with bad policy name', function(done) {
+    expect(CONSTANTS.POLICY_REGEX.test('signin')).to.equal(false);
+    expect(CONSTANTS.POLICY_REGEX.test('b2c_SIGNIN')).to.equal(false);
+    expect(CONSTANTS.POLICY_REGEX.test('b2c_1_')).to.equal(false);
+    expect(CONSTANTS.POLICY_REGEX.test('b2c_1_*SIGNIN')).to.equal(false);
+    done();
+  });
+});
+
+describe('tenant name checking', function() {
+  it('should pass with good tenant name', function(done) {
+    expect(CONSTANTS.TENANTNAME_REGEX.test('contoso123COMPANY.onmicrosoft.com')).to.equal(true);
+    done();
+  });
+
+  it('should fail with bad tenant name', function(done) {
+    expect(CONSTANTS.TENANTNAME_REGEX.test('contoso.onmicrosoft.comm')).to.equal(false);
+    expect(CONSTANTS.TENANTNAME_REGEX.test('contoso123COMPANY')).to.equal(false);
+    expect(CONSTANTS.TENANTNAME_REGEX.test('.onmicrosoft.com')).to.equal(false);
+    expect(CONSTANTS.TENANTNAME_REGEX.test('contoso123COMPANY.ONMICROSOFT.com')).to.equal(false);
+    expect(CONSTANTS.TENANTNAME_REGEX.test('contoso_company.onmicrosoft.com')).to.equal(false);
+    done();
+  });
+});
+
+describe('tenant id checking', function() {
+  it('should pass with good tenant id', function(done) {
+    expect(CONSTANTS.TENANTID_REGEX.test('683eAd13-3193-43f0-9677-d727c25a588f')).to.equal(true);
+    done();
+  });
+
+  it('should fail with bad tenant id', function(done) {
+    expect(CONSTANTS.TENANTID_REGEX.test('23_12')).to.equal(false);
+    done();
+  });
+});
+

--- a/test/Chai-passport_test/oidc_dynamic_tenant_test.js
+++ b/test/Chai-passport_test/oidc_dynamic_tenant_test.js
@@ -33,15 +33,15 @@ chai.use(require('chai-passport-strategy'));
 
 // Mock options required to create a OIDC strategy
 var options = {
-    redirectUrl: 'https://returnURL',
-    clientID: 'my_client_id',
-    clientSecret: 'my_client_secret',
-    identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
-    responseType: 'id_token',
-    responseMode: 'form_post',
-    validateIssuer: true,
-    passReqToCallback: false,
-    sessionKey: 'my_key'    //optional sessionKey
+  redirectUrl: 'https://returnURL',
+  clientID: 'my_client_id',
+  clientSecret: 'my_client_secret',
+  identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
+  responseType: 'id_token',
+  responseMode: 'form_post',
+  validateIssuer: true,
+  passReqToCallback: false,
+  sessionKey: 'my_key'    //optional sessionKey
 };
 
 describe('OIDCStrategy dynamic tenant test', function() {
@@ -50,25 +50,25 @@ describe('OIDCStrategy dynamic tenant test', function() {
   var request;
 
   var testPrepare = function(validateIssuer, issuer, tenantIdOrName, isB2C, policy) {
-  	return function(done) {
+    return function(done) {
       options.validateIssuer = validateIssuer;
       options.issuer = issuer;
       options.isB2C = isB2C;
 
       var testStrategy = new OIDCStrategy(options, function(profile, done) {});
 
-  		chai.passport
-  		  .use(testStrategy)
+      chai.passport
+        .use(testStrategy)
         .redirect(function(u) {redirectUrl = u; done(); })
         .fail(function(c) {challenge = c; done(); })
-  		  .req(function(req) {
+        .req(function(req) {
           request = req;
           req.session = {}; 
           req.query = {}; 
           challenge = null;
         })
-  		  .authenticate({ tenantIdOrName: tenantIdOrName });
-  	};
+       .authenticate({ tenantIdOrName: tenantIdOrName });
+    };
   };
 
   describe('should succeed', function() {

--- a/test/Chai-passport_test/oidc_hybrid_and_code_flow_test.js
+++ b/test/Chai-passport_test/oidc_hybrid_and_code_flow_test.js
@@ -133,7 +133,7 @@ var setReqFromAuthRespRedirect = function(id_token_in_auth_resp, code_in_auth_re
       optionsToValidate.algorithms = ['RS256'];
       optionsToValidate.nonce = nonce_to_use;
 
-      oauthConfig.auth_endpoint = "https://login.microsoftonline.com/268da1a1-9db4-48b9-b1fe-683250ba90cc/oauth2/authorize";
+      oauthConfig.authorization_endpoint = "https://login.microsoftonline.com/268da1a1-9db4-48b9-b1fe-683250ba90cc/oauth2/authorize";
       oauthConfig.redirectUrl = "http://localhost:3000/auth/openid/return";
       oauthConfig.clientID = "2abf3a52-7d86-460b-a1ef-77dc43de8aad";
       oauthConfig.token_endpoint = "https://login.microsoftonline.com/268da1a1-9db4-48b9-b1fe-683250ba90cc/oauth2/token";


### PR DESCRIPTION
Removes dependency on `oniyi-logger` (installed via `oniyi-object-transform`) which was configured to support Node `^4.2.4` (we support newer versions). This dependency was removed in AzureAD/passport-azure-ad: https://github.com/AzureAD/passport-azure-ad/commit/505bfba583e161c0a7e44b92430823b201d31226

I ran `npm i && npm test`, which exited successfully (`68 assertions passed`).